### PR TITLE
Fix DBus slot

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -43,8 +43,9 @@ parts:
       cd "/snap/$snap/current" && find . -type f,l -exec rm -f "$SNAPCRAFT_PRIME/{}" \;
       done
 
-plugs:
-  curtail:
+slots:
+  # for GtkApplication registration
+  paper:
     interface: dbus
     bus: session
     name: io.posidon.Paper


### PR DESCRIPTION
The DBus interface was defined as a plug instead of a slot. That prevented the application from running.

This patch fixes it.